### PR TITLE
Setup Github workflow: PR and issue templates, contributing guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/PULL_REQUEST_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Description
+
+<!-- Summarize your changes, link to issues, and describe the purpose. -->
+
+## Checklist
+
+- [ ] Code builds and runs locally
+- [ ] Docs updated (if needed)
+- [ ] Linked to an issue (if applicable)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,31 @@
+name: "🐞 Bug Report"
+description: Report a reproducible bug
+labels: [bug]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: Short summary
+      placeholder: e.g. "Navbar breaks on mobile"
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: "How can we see the bug?"
+      placeholder: "1. Go to...\n2. Click on..."
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+    validations:
+      required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing to Rocket Starter Web
+
+Thank you for helping build Rocket Starter Web!
+
+## How We Work
+
+- All work happens in feature branches (e.g., `feature/your-feature`)
+- Open a Pull Request to `main` when ready
+- Link PRs to issues when possible
+- Keep commits focused and clear
+- Use the provided issue and PR templates
+
+**Questions?** Open an issue or start a discussion!


### PR DESCRIPTION
## What’s new

- Added .github/ISSUE_TEMPLATE/ with bug and feature request templates
- Added PULL_REQUEST_TEMPLATE.md for PRs
- Added CONTRIBUTING.md to document workflow

## Why

Establishes a professional, repeatable development workflow and prepares the repo for collaboration.

## Next steps

Team can now use templates when submitting bugs, features, or PRs.
